### PR TITLE
bump aws sdk to v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ targetCompatibility = 1.8
 
 dependencies {
     def embulkVersion = "0.10.43"
-    def awsSdkVersion = "1.12.406"
+    def awsSdkVersion = "2.20.26"
     compileOnly "org.embulk:embulk-api:${embulkVersion}"
     compileOnly "org.embulk:embulk-spi:${embulkVersion}"
     implementation "org.scala-lang:scala-library:2.13.10"
@@ -39,11 +39,15 @@ dependencies {
     implementation "org.embulk:embulk-util-config:0.3.2"
     implementation "org.embulk:embulk-util-json:0.3.0"
     implementation "org.embulk:embulk-util-timestamp:0.2.2"
-    implementation("com.amazonaws:aws-java-sdk-dynamodb:${awsSdkVersion}") {
+    implementation("software.amazon.awssdk:dynamodb:${awsSdkVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.dataformat'
     }
-    implementation("com.amazonaws:aws-java-sdk-sts:${awsSdkVersion}") {
+    implementation("software.amazon.awssdk:sts:${awsSdkVersion}") {
+        exclude group: 'com.fasterxml.jackson.core'
+        exclude group: 'com.fasterxml.jackson.dataformat'
+    }
+    implementation("software.amazon.awssdk:apache-client:${awsSdkVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.dataformat'
     }

--- a/src/main/scala/org/embulk/input/dynamodb/aws/AwsDynamodbConfiguration.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/aws/AwsDynamodbConfiguration.scala
@@ -2,7 +2,8 @@ package org.embulk.input.dynamodb.aws
 
 import java.util.Optional
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder
 import org.embulk.util.config.{Config, ConfigDefault, Task => EmbulkTask}
 import org.embulk.input.dynamodb.aws.AwsDynamodbConfiguration.Task
 
@@ -23,12 +24,11 @@ object AwsDynamodbConfiguration {
 
 class AwsDynamodbConfiguration(task: Task) {
 
-  def configureAmazonDynamoDBClientBuilder(
-      builder: AmazonDynamoDBClientBuilder
+  def configureDynamoDbClientBuilder(
+      builder: DynamoDbClientBuilder
   ): Unit = {
     task.getEnableEndpointDiscovery.ifPresent { v =>
-      if (v) builder.enableEndpointDiscovery()
-      else builder.disableEndpointDiscovery()
+      builder.endpointDiscoveryEnabled(v)
     }
   }
 

--- a/src/main/scala/org/embulk/input/dynamodb/item/DynamodbAttributeValueEmbulkTypeTransformable.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/item/DynamodbAttributeValueEmbulkTypeTransformable.scala
@@ -1,8 +1,8 @@
 package org.embulk.input.dynamodb.item
 
-import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
+import software.amazon.awssdk.core.SdkBytes
 import org.embulk.input.dynamodb.logger
 import org.embulk.spi.time.Timestamp
 import org.embulk.util.timestamp.TimestampFormatter
@@ -65,8 +65,8 @@ case class DynamodbAttributeValueEmbulkTypeTransformable(
     }
   }
 
-  private def convertBAsString(b: ByteBuffer): String = {
-    new String(b.array(), StandardCharsets.UTF_8)
+  private def convertBAsString(b: SdkBytes): String = {
+    new String(b.asByteArray(), StandardCharsets.UTF_8)
   }
 
   private def hasAttributeValueType: Boolean = {
@@ -86,7 +86,7 @@ case class DynamodbAttributeValueEmbulkTypeTransformable(
           case Right(v) => ValueFactory.newFloat(v)
         }
       case DynamodbAttributeValueType.B =>
-        ValueFactory.newBinary(attributeValue.getB.array())
+        ValueFactory.newBinary(attributeValue.getB.asByteArray())
       case DynamodbAttributeValueType.SS =>
         ValueFactory.newArray(
           attributeValue.getSS.asScala.map(ValueFactory.newString).asJava
@@ -103,7 +103,7 @@ case class DynamodbAttributeValueEmbulkTypeTransformable(
       case DynamodbAttributeValueType.BS =>
         ValueFactory.newArray(
           attributeValue.getBS.asScala
-            .map(b => ValueFactory.newBinary(b.array()))
+            .map(b => ValueFactory.newBinary(b.asByteArray()))
             .asJava
         )
       case DynamodbAttributeValueType.M =>

--- a/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemConsumer.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemConsumer.scala
@@ -1,6 +1,6 @@
 package org.embulk.input.dynamodb.item
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import org.embulk.spi.PageBuilder
 
 object DynamodbItemConsumer {

--- a/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemIterator.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemIterator.scala
@@ -1,6 +1,6 @@
 package org.embulk.input.dynamodb.item
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 object DynamodbItemIterator {
 

--- a/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemSchema.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemSchema.scala
@@ -2,7 +2,7 @@ package org.embulk.input.dynamodb.item
 
 import java.util.{Optional, List => JList}
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import com.fasterxml.jackson.annotation.{JsonCreator, JsonValue}
 import org.embulk.util.config.{Config, ConfigDefault, Task => EmbulkTask}
 import org.embulk.spi.{Column, PageBuilder, Schema}

--- a/src/main/scala/org/embulk/input/dynamodb/operation/AbstractDynamodbOperation.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/operation/AbstractDynamodbOperation.scala
@@ -8,7 +8,7 @@ import java.lang.{
 }
 import java.util.{Optional, Map => JMap}
 
-import com.amazonaws.services.dynamodbv2.model.{
+import software.amazon.awssdk.services.dynamodb.model.{
   AttributeValue,
   ReturnConsumedCapacity,
   Select
@@ -90,17 +90,17 @@ object AbstractDynamodbOperation {
   }
 
   type RequestBuilderMethods = {
-    def setConsistentRead(v: JBoolean): Unit
-    def setExclusiveStartKey(v: JMap[JString, AttributeValue]): Unit
-    def setExpressionAttributeNames(v: JMap[JString, JString]): Unit
-    def setExpressionAttributeValues(v: JMap[JString, AttributeValue]): Unit
-    def setFilterExpression(v: JString): Unit
-    def setIndexName(v: JString): Unit
-    def setLimit(v: JInteger): Unit
-    def setProjectionExpression(v: JString): Unit
-    def setReturnConsumedCapacity(v: ReturnConsumedCapacity): Unit
-    def setSelect(v: Select): Unit
-    def setTableName(v: JString): Unit
+    def consistentRead(v: JBoolean): Any
+    def exclusiveStartKey(v: JMap[JString, AttributeValue]): Any
+    def expressionAttributeNames(v: JMap[JString, JString]): Any
+    def expressionAttributeValues(v: JMap[JString, AttributeValue]): Any
+    def filterExpression(v: JString): Any
+    def indexName(v: JString): Any
+    def limit(v: JInteger): Any
+    def projectionExpression(v: JString): Any
+    def returnConsumedCapacity(v: ReturnConsumedCapacity): Any
+    def select(v: Select): Any
+    def tableName(v: JString): Any
   }
 
 }
@@ -128,12 +128,12 @@ abstract class AbstractDynamodbOperation(
       (x._1, DynamodbAttributeValue(x._2).getOriginal)
     }
 
-    req.setConsistentRead(task.getConsistentRead)
+    req.consistentRead(task.getConsistentRead)
     lastEvaluatedKey match {
-      case Some(v) => req.setExclusiveStartKey(v.asJava)
+      case Some(v) => req.exclusiveStartKey(v.asJava)
       case None =>
         if (!task.getExclusiveStartKey.isEmpty)
-          req.setExclusiveStartKey(
+          req.exclusiveStartKey(
             task.getExclusiveStartKey.asScala
               .map(attributeValueTaskToAttributeValue)
               .asJava
@@ -141,27 +141,27 @@ abstract class AbstractDynamodbOperation(
     }
 
     if (!task.getExpressionAttributeNames.isEmpty)
-      req.setExpressionAttributeNames(task.getExpressionAttributeNames)
+      req.expressionAttributeNames(task.getExpressionAttributeNames)
     if (!task.getExpressionAttributeValues.isEmpty)
-      req.setExpressionAttributeValues(
+      req.expressionAttributeValues(
         task.getExpressionAttributeValues.asScala
           .map(attributeValueTaskToAttributeValue)
           .asJava
       )
-    task.getFilterExpression.ifPresent(req.setFilterExpression)
-    task.getIndexName.ifPresent(req.setIndexName)
+    task.getFilterExpression.ifPresent(req.filterExpression)
+    task.getIndexName.ifPresent(req.indexName)
     task.getBatchSize.ifPresent { v =>
       if (v <= 0)
         throw new ConfigException(
           "\"batch_size\" must be greater than or equal to 1."
         )
-      req.setLimit(
+      req.limit(
         JInteger.valueOf(v)
       ) // Note: Use BatchSize for the limit per a request.
     }
-    task.getProjectionExpression.ifPresent(req.setProjectionExpression)
-    task.getReturnConsumedCapacity.ifPresent(req.setReturnConsumedCapacity)
-    task.getSelect.ifPresent(req.setSelect)
-    req.setTableName(task.getTableName)
+    task.getProjectionExpression.ifPresent(req.projectionExpression)
+    task.getReturnConsumedCapacity.ifPresent(req.returnConsumedCapacity)
+    task.getSelect.ifPresent(req.select)
+    req.tableName(task.getTableName)
   }
 }

--- a/src/main/scala/org/embulk/input/dynamodb/operation/DynamodbOperationProxy.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/operation/DynamodbOperationProxy.scala
@@ -2,8 +2,8 @@ package org.embulk.input.dynamodb.operation
 
 import java.util.Optional
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import org.embulk.config.ConfigException
 import org.embulk.util.config.{Config, ConfigDefault, Task => EmbulkTask}
 import org.embulk.input.dynamodb.operation.{
@@ -53,7 +53,7 @@ case class DynamodbOperationProxy(task: DynamodbOperationProxy.Task)
   override def getEmbulkTaskCount: Int = operation.getEmbulkTaskCount
 
   override def run(
-      dynamodb: AmazonDynamoDB,
+      dynamodb: DynamoDbClient,
       embulkTaskIndex: Int,
       f: Seq[Map[String, AttributeValue]] => Unit
   ): Unit = operation.run(dynamodb, embulkTaskIndex, f)

--- a/src/main/scala/org/embulk/input/dynamodb/operation/EmbulkDynamodbOperation.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/operation/EmbulkDynamodbOperation.scala
@@ -1,14 +1,14 @@
 package org.embulk.input.dynamodb.operation
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 trait EmbulkDynamodbOperation {
 
   def getEmbulkTaskCount: Int = 1
 
   def run(
-      dynamodb: AmazonDynamoDB,
+      dynamodb: DynamoDbClient,
       embulkTaskIndex: Int,
       f: Seq[Map[String, AttributeValue]] => Unit
   ): Unit

--- a/src/test/scala/org/embulk/input/dynamodb/AwsCredentialsTest.scala
+++ b/src/test/scala/org/embulk/input/dynamodb/AwsCredentialsTest.scala
@@ -1,5 +1,6 @@
 package org.embulk.input.dynamodb
 
+import software.amazon.awssdk.core.exception.SdkClientException
 import software.amazon.awssdk.services.sts.model.StsException
 import org.embulk.config.{ConfigSource, ConfigException}
 import org.embulk.input.dynamodb.aws.AwsCredentials
@@ -114,7 +115,7 @@ class AwsCredentialsTest extends EmbulkTestBase {
       .set("profile_name", "DO_NOT_EXIST")
 
     Assert.assertThrows(
-      classOf[IllegalArgumentException],
+      classOf[SdkClientException],
       () => {
         doTest(inConfig)
       }

--- a/src/test/scala/org/embulk/input/dynamodb/AwsCredentialsTest.scala
+++ b/src/test/scala/org/embulk/input/dynamodb/AwsCredentialsTest.scala
@@ -1,6 +1,6 @@
 package org.embulk.input.dynamodb
 
-import com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException
+import software.amazon.awssdk.services.sts.model.StsException
 import org.embulk.config.{ConfigSource, ConfigException}
 import org.embulk.input.dynamodb.aws.AwsCredentials
 import org.embulk.input.dynamodb.testutil.EmbulkTestBase
@@ -38,9 +38,9 @@ class AwsCredentialsTest extends EmbulkTestBase {
   def doTest(inConfig: ConfigSource): Unit = {
     val task: PluginTask = PluginTask.load(inConfig)
     val provider = AwsCredentials(task).createAwsCredentialsProvider
-    val cred = provider.getCredentials
-    assertThat(cred.getAWSAccessKeyId, notNullValue())
-    assertThat(cred.getAWSSecretKey, notNullValue())
+    val cred = provider.resolveCredentials()
+    assertThat(cred.accessKeyId(), notNullValue())
+    assertThat(cred.secretAccessKey(), notNullValue())
   }
 
   def defaultInConfig: ConfigSource = {
@@ -140,7 +140,7 @@ class AwsCredentialsTest extends EmbulkTestBase {
         .set("role_session_name", "dummy")
 
       Assert.assertThrows(
-        classOf[AWSSecurityTokenServiceException],
+        classOf[StsException],
         () => {
           doTest(inConfig)
         }

--- a/src/test/scala/org/embulk/input/dynamodb/DynamodbOperationTest.scala
+++ b/src/test/scala/org/embulk/input/dynamodb/DynamodbOperationTest.scala
@@ -1,6 +1,6 @@
 package org.embulk.input.dynamodb
 
-import com.amazonaws.services.dynamodbv2.model.{
+import software.amazon.awssdk.services.dynamodb.model.{
   AttributeDefinition,
   AttributeValue,
   BillingMode,
@@ -33,74 +33,80 @@ class DynamodbOperationTest extends EmbulkTestBase {
     cleanupTable(tableName)
     withDynamodb { dynamodb =>
       dynamodb.createTable(
-        new CreateTableRequest()
-          .withTableName(tableName)
-          .withAttributeDefinitions(
-            new AttributeDefinition()
-              .withAttributeName("pk")
-              .withAttributeType(ScalarAttributeType.S)
+        CreateTableRequest
+          .builder()
+          .tableName(tableName)
+          .attributeDefinitions(
+            AttributeDefinition
+              .builder()
+              .attributeName("pk")
+              .attributeType(ScalarAttributeType.S)
+              .build()
           )
-          .withKeySchema(
-            new KeySchemaElement()
-              .withAttributeName("pk")
-              .withKeyType(KeyType.HASH)
+          .keySchema(
+            KeySchemaElement
+              .builder()
+              .attributeName("pk")
+              .keyType(KeyType.HASH)
+              .build()
           )
-          .withBillingMode(BillingMode.PAY_PER_REQUEST)
+          .billingMode(BillingMode.PAY_PER_REQUEST)
+          .build()
       )
       dynamodb.putItem(
-        new PutItemRequest()
-          .withTableName(tableName)
-          .withItem(
-            Map
-              .newBuilder[String, AttributeValue]
-              .addOne("pk", new AttributeValue().withS("a"))
-              .result()
-              .asJava
+        PutItemRequest
+          .builder()
+          .tableName(tableName)
+          .item(
+            Map(
+              "pk" -> AttributeValue.builder().s("a").build()
+            ).asJava
           )
+          .build()
       )
       dynamodb.putItem(
-        new PutItemRequest()
-          .withTableName(tableName)
-          .withItem(
-            Map
-              .newBuilder[String, AttributeValue]
-              .addOne("pk", new AttributeValue().withS("a"))
-              .result()
-              .asJava
+        PutItemRequest
+          .builder()
+          .tableName(tableName)
+          .item(
+            Map(
+              "pk" -> AttributeValue.builder().s("a").build()
+            ).asJava
           )
+          .build()
       )
       dynamodb.putItem(
-        new PutItemRequest()
-          .withTableName(tableName)
-          .withItem(
-            Map
-              .newBuilder[String, AttributeValue]
-              .addOne("pk", new AttributeValue().withS("a"))
-              .result()
-              .asJava
+        PutItemRequest
+          .builder()
+          .tableName(tableName)
+          .item(
+            Map(
+              "pk" -> AttributeValue.builder().s("a").build()
+            ).asJava
           )
+          .build()
       )
       dynamodb.putItem(
-        new PutItemRequest()
-          .withTableName(tableName)
-          .withItem(
-            Map
-              .newBuilder[String, AttributeValue]
-              .addOne("pk", new AttributeValue().withS("b"))
-              .result()
-              .asJava
+        PutItemRequest
+          .builder()
+          .tableName(tableName)
+          .item(
+            Map(
+              "pk" -> AttributeValue.builder().s("b").build()
+            ).asJava
           )
+          .build()
       )
       dynamodb.putItem(
-        new PutItemRequest()
-          .withTableName(tableName)
-          .withItem(
-            Map
-              .newBuilder[String, AttributeValue]
-              .addOne("pk", new AttributeValue().withS("b"))
-              .result()
-              .asJava
+        PutItemRequest
+          .builder()
+          .tableName(tableName)
+          .item(
+            Map(
+              "pk" -> AttributeValue.builder().s("b").build()
+            ).asJava
           )
+          .build()
       )
     }
 

--- a/src/test/scala/org/embulk/input/dynamodb/DynamodbQueryOperationBackwardCompatibilityTest.scala
+++ b/src/test/scala/org/embulk/input/dynamodb/DynamodbQueryOperationBackwardCompatibilityTest.scala
@@ -1,6 +1,6 @@
 package org.embulk.input.dynamodb
 
-import com.amazonaws.services.dynamodbv2.model.{
+import software.amazon.awssdk.services.dynamodb.model.{
   AttributeDefinition,
   AttributeValue,
   CreateTableRequest,
@@ -25,65 +25,75 @@ class DynamodbQueryOperationBackwardCompatibilityTest extends EmbulkTestBase {
     cleanupTable("EMBULK_DYNAMODB_TEST_TABLE")
     withDynamodb { dynamodb =>
       dynamodb.createTable(
-        new CreateTableRequest()
-          .withTableName("EMBULK_DYNAMODB_TEST_TABLE")
-          .withAttributeDefinitions(
-            new AttributeDefinition()
-              .withAttributeName("pri-key")
-              .withAttributeType(ScalarAttributeType.S),
-            new AttributeDefinition()
-              .withAttributeName("sort-key")
-              .withAttributeType(ScalarAttributeType.N)
+        CreateTableRequest
+          .builder()
+          .tableName("EMBULK_DYNAMODB_TEST_TABLE")
+          .attributeDefinitions(
+            AttributeDefinition
+              .builder()
+              .attributeName("pri-key")
+              .attributeType(ScalarAttributeType.S)
+              .build(),
+            AttributeDefinition
+              .builder()
+              .attributeName("sort-key")
+              .attributeType(ScalarAttributeType.N)
+              .build()
           )
-          .withKeySchema(
-            new KeySchemaElement()
-              .withAttributeName("pri-key")
-              .withKeyType(KeyType.HASH),
-            new KeySchemaElement()
-              .withAttributeName("sort-key")
-              .withKeyType(KeyType.RANGE)
+          .keySchema(
+            KeySchemaElement
+              .builder()
+              .attributeName("pri-key")
+              .keyType(KeyType.HASH)
+              .build(),
+            KeySchemaElement
+              .builder()
+              .attributeName("sort-key")
+              .keyType(KeyType.RANGE)
+              .build()
           )
-          .withProvisionedThroughput(
-            new ProvisionedThroughput()
-              .withReadCapacityUnits(5L)
-              .withWriteCapacityUnits(5L)
+          .provisionedThroughput(
+            ProvisionedThroughput
+              .builder()
+              .readCapacityUnits(5L)
+              .writeCapacityUnits(5L)
+              .build()
           )
+          .build()
       )
 
       dynamodb.putItem(
-        new PutItemRequest()
-          .withTableName("EMBULK_DYNAMODB_TEST_TABLE")
-          .withItem(
-            Map
-              .newBuilder[String, AttributeValue]
-              .addOne("pri-key", new AttributeValue().withS("key-1"))
-              .addOne("sort-key", new AttributeValue().withN("0"))
-              .addOne("doubleValue", new AttributeValue().withN("42.195"))
-              .addOne("boolValue", new AttributeValue().withBOOL(true))
-              .addOne(
-                "listValue",
-                new AttributeValue().withL(
-                  new AttributeValue().withS("list-value"),
-                  new AttributeValue().withN("123")
+        PutItemRequest
+          .builder()
+          .tableName("EMBULK_DYNAMODB_TEST_TABLE")
+          .item(
+            Map(
+              "pri-key" -> AttributeValue.builder().s("key-1").build(),
+              "sort-key" -> AttributeValue.builder().n("0").build(),
+              "doubleValue" -> AttributeValue.builder().n("42.195").build(),
+              "boolValue" -> AttributeValue.builder().bool(true).build(),
+              "listValue" -> AttributeValue
+                .builder()
+                .l(
+                  AttributeValue.builder().s("list-value").build(),
+                  AttributeValue.builder().n("123").build()
                 )
-              )
-              .addOne(
-                "mapValue",
-                new AttributeValue().withM(
-                  Map
-                    .newBuilder[String, AttributeValue]
-                    .addOne(
-                      "map-key-1",
-                      new AttributeValue().withS("map-value-1")
-                    )
-                    .addOne("map-key-2", new AttributeValue().withN("456"))
-                    .result()
-                    .asJava
+                .build(),
+              "mapValue" -> AttributeValue
+                .builder()
+                .m(
+                  Map(
+                    "map-key-1" -> AttributeValue
+                      .builder()
+                      .s("map-value-1")
+                      .build(),
+                    "map-key-2" -> AttributeValue.builder().n("456").build()
+                  ).asJava
                 )
-              )
-              .result()
-              .asJava
+                .build()
+            ).asJava
           )
+          .build()
       )
     }
 

--- a/src/test/scala/org/embulk/input/dynamodb/DynamodbScanOperationBackwardCompatibilityTest.scala
+++ b/src/test/scala/org/embulk/input/dynamodb/DynamodbScanOperationBackwardCompatibilityTest.scala
@@ -1,6 +1,6 @@
 package org.embulk.input.dynamodb
 
-import com.amazonaws.services.dynamodbv2.model.{
+import software.amazon.awssdk.services.dynamodb.model.{
   AttributeDefinition,
   AttributeValue,
   CreateTableRequest,
@@ -25,65 +25,75 @@ class DynamodbScanOperationBackwardCompatibilityTest extends EmbulkTestBase {
     cleanupTable("EMBULK_DYNAMODB_TEST_TABLE")
     withDynamodb { dynamodb =>
       dynamodb.createTable(
-        new CreateTableRequest()
-          .withTableName("EMBULK_DYNAMODB_TEST_TABLE")
-          .withAttributeDefinitions(
-            new AttributeDefinition()
-              .withAttributeName("pri-key")
-              .withAttributeType(ScalarAttributeType.S),
-            new AttributeDefinition()
-              .withAttributeName("sort-key")
-              .withAttributeType(ScalarAttributeType.N)
+        CreateTableRequest
+          .builder()
+          .tableName("EMBULK_DYNAMODB_TEST_TABLE")
+          .attributeDefinitions(
+            AttributeDefinition
+              .builder()
+              .attributeName("pri-key")
+              .attributeType(ScalarAttributeType.S)
+              .build(),
+            AttributeDefinition
+              .builder()
+              .attributeName("sort-key")
+              .attributeType(ScalarAttributeType.N)
+              .build()
           )
-          .withKeySchema(
-            new KeySchemaElement()
-              .withAttributeName("pri-key")
-              .withKeyType(KeyType.HASH),
-            new KeySchemaElement()
-              .withAttributeName("sort-key")
-              .withKeyType(KeyType.RANGE)
+          .keySchema(
+            KeySchemaElement
+              .builder()
+              .attributeName("pri-key")
+              .keyType(KeyType.HASH)
+              .build(),
+            KeySchemaElement
+              .builder()
+              .attributeName("sort-key")
+              .keyType(KeyType.RANGE)
+              .build()
           )
-          .withProvisionedThroughput(
-            new ProvisionedThroughput()
-              .withReadCapacityUnits(5L)
-              .withWriteCapacityUnits(5L)
+          .provisionedThroughput(
+            ProvisionedThroughput
+              .builder()
+              .readCapacityUnits(5L)
+              .writeCapacityUnits(5L)
+              .build()
           )
+          .build()
       )
 
       dynamodb.putItem(
-        new PutItemRequest()
-          .withTableName("EMBULK_DYNAMODB_TEST_TABLE")
-          .withItem(
-            Map
-              .newBuilder[String, AttributeValue]
-              .addOne("pri-key", new AttributeValue().withS("key-1"))
-              .addOne("sort-key", new AttributeValue().withN("0"))
-              .addOne("doubleValue", new AttributeValue().withN("42.195"))
-              .addOne("boolValue", new AttributeValue().withBOOL(true))
-              .addOne(
-                "listValue",
-                new AttributeValue().withL(
-                  new AttributeValue().withS("list-value"),
-                  new AttributeValue().withN("123")
+        PutItemRequest
+          .builder()
+          .tableName("EMBULK_DYNAMODB_TEST_TABLE")
+          .item(
+            Map(
+              "pri-key" -> AttributeValue.builder().s("key-1").build(),
+              "sort-key" -> AttributeValue.builder().n("0").build(),
+              "doubleValue" -> AttributeValue.builder().n("42.195").build(),
+              "boolValue" -> AttributeValue.builder().bool(true).build(),
+              "listValue" -> AttributeValue
+                .builder()
+                .l(
+                  AttributeValue.builder().s("list-value").build(),
+                  AttributeValue.builder().n("123").build()
                 )
-              )
-              .addOne(
-                "mapValue",
-                new AttributeValue().withM(
-                  Map
-                    .newBuilder[String, AttributeValue]
-                    .addOne(
-                      "map-key-1",
-                      new AttributeValue().withS("map-value-1")
-                    )
-                    .addOne("map-key-2", new AttributeValue().withN("456"))
-                    .result()
-                    .asJava
+                .build(),
+              "mapValue" -> AttributeValue
+                .builder()
+                .m(
+                  Map(
+                    "map-key-1" -> AttributeValue
+                      .builder()
+                      .s("map-value-1")
+                      .build(),
+                    "map-key-2" -> AttributeValue.builder().n("456").build()
+                  ).asJava
                 )
-              )
-              .result()
-              .asJava
+                .build()
+            ).asJava
           )
+          .build()
       )
     }
 


### PR DESCRIPTION
ref: https://aws.amazon.com/jp/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/

The AWS SDK for Java v1.x will enter maintenance mode on July 31, 2024, and reach end-of-support on December 31, 2025.