### PR TITLE
fix: error cropped up when type is timestamp

### DIFF
--- a/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemReader.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/item/DynamodbItemReader.scala
@@ -53,10 +53,11 @@ case class DynamodbItemReader(
       .get(column.getName)
       .flatMap(v => getTransformable(column.getName, v).asDouble)
 
-  def getTimestamp(column: Column): Option[Instant] =
+  def getTimestamp(column: Column): Option[Timestamp] =
     currentItem
       .get(column.getName)
       .flatMap(v => getTransformable(column.getName, v).asTimestamp)
+      .map(instant => Timestamp.ofInstant(instant))
 
   def getJson(column: Column): Option[Value] =
     currentItem


### PR DESCRIPTION
fixed error cropped up when type is timestamp

<details>

```
2025-11-10 00:20:16.479 +0000 [ERROR]: /work/embulk_bundle/jruby/2.3.0/gems/mutex_m-0.1.2/lib/mutex_m.rb:110: warning: toplevel constant Mutex referenced by Thread::Mutex
2025-11-10 00:20:19.510 +0000 [ERROR]: org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: java.lang.NoSuchMethodError: org.embulk.spi.PageBuilder.setTimestamp(Lorg/embulk/spi/Column;Ljava/time/Instant;)V
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:340)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:566)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:353)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:350)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.spi.Exec.doWith(Exec.java:22)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.run(BulkLoader.java:350)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:242)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:290)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.EmbulkRunner.run(EmbulkRunner.java:155)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:431)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.cli.Main.main(Main.java:64)
2025-11-10 00:20:19.510 +0000 [ERROR]: Caused by: java.lang.RuntimeException: java.lang.NoSuchMethodError: org.embulk.spi.PageBuilder.setTimestamp(Lorg/embulk/spi/Column;Ljava/time/Instant;)V
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$LoaderState.getRepresentativeException(org/embulk/exec/BulkLoader.java:285)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.execute(org/embulk/exec/BulkLoader.java:684)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.access$300(org/embulk/exec/BulkLoader.java:35)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$4$1$1$1.run(org/embulk/exec/BulkLoader.java:528)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
2025-11-10 00:20:19.510 +0000 [ERROR]: 	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:453)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:314)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at RUBY.block in transaction(uri:classloader:/gems/embulk-0.9.27-java/lib/embulk/output_plugin.rb:66)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at RUBY.transaction(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.7.5.trocco.0.0.2/lib/embulk/output/bigquery.rb:399)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at RUBY.transaction(uri:classloader:/gems/embulk-0.9.27-java/lib/embulk/output_plugin.rb:64)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at Embulk$$OutputPlugin$$JavaAdapter_1299603672.transaction(Embulk$$OutputPlugin$$JavaAdapter_1299603672.gen:13)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$4$1$1.transaction(org/embulk/exec/BulkLoader.java:521)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.exec.LocalExecutorPlugin.transaction(org/embulk/exec/LocalExecutorPlugin.java:50)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$4$1.run(org/embulk/exec/BulkLoader.java:516)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:84)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl$1.run(org/embulk/spi/util/Filters.java:80)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.filter.internal_http.InternalHttpFilterPlugin.transaction(org/embulk/filter/internal_http/InternalHttpFilterPlugin.java:82)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:76)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl$1.run(org/embulk/spi/util/Filters.java:80)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.filter.typecast.TypecastFilterPlugin.transaction(org/embulk/filter/typecast/TypecastFilterPlugin.java:89)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:76)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl$1.run(org/embulk/spi/util/Filters.java:80)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.filter.column.ColumnFilterPlugin.transaction(org/embulk/filter/column/ColumnFilterPlugin.java:81)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:76)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl$1.run(org/embulk/spi/util/Filters.java:80)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.filter.SpeedometerFilterPlugin.transaction(org/embulk/filter/SpeedometerFilterPlugin.java:83)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:76)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.spi.util.Filters.transaction(org/embulk/spi/util/Filters.java:42)
2025-11-10 00:20:19.511 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$4.run(org/embulk/exec/BulkLoader.java:511)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.DynamodbInputPlugin.transaction(org/embulk/input/dynamodb/DynamodbInputPlugin.scala:21)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:507)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:35)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:353)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:350)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:22)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:350)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:242)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.EmbulkRunner.runInternal(org/embulk/EmbulkRunner.java:290)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.EmbulkRunner.run(org/embulk/EmbulkRunner.java:155)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.cli.EmbulkRun.runSubcommand(org/embulk/cli/EmbulkRun.java:431)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.cli.EmbulkRun.run(org/embulk/cli/EmbulkRun.java:90)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.cli.Main.main(org/embulk/cli/Main.java:64)
2025-11-10 00:20:19.512 +0000 [ERROR]: Caused by: java.lang.NoSuchMethodError: org.embulk.spi.PageBuilder.setTimestamp(Lorg/embulk/spi/Column;Ljava/time/Instant;)V
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.item.DynamodbItemColumnVisitor.timestampColumn(DynamodbItemColumnVisitor.scala:39)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.spi.Column.visit(Column.java:54)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.spi.Schema.visitColumns(Schema.java:68)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.item.DynamodbItemSchema.visitColumns(DynamodbItemSchema.scala:138)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.item.DynamodbItemConsumer$.$anonfun$consumeItemsByEmbulkSchema$1(DynamodbItemConsumer.scala:35)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.item.DynamodbItemConsumer$.$anonfun$consumeItemsByEmbulkSchema$1$adapted(DynamodbItemConsumer.scala:30)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.operation.DynamodbScanOperation.runInternal(DynamodbScanOperation.scala:82)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.operation.DynamodbScanOperation.run(DynamodbScanOperation.scala:102)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.operation.DynamodbOperationProxy.run(DynamodbOperationProxy.scala:59)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.DynamodbInputPlugin.$anonfun$run$1(DynamodbInputPlugin.scala:47)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.DynamodbInputPlugin.$anonfun$run$1$adapted(DynamodbInputPlugin.scala:43)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.aws.Aws.withDynamodb(Aws.scala:35)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.input.dynamodb.DynamodbInputPlugin.run(DynamodbInputPlugin.scala:43)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:269)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$100(LocalExecutorPlugin.java:194)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:233)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:230)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2025-11-10 00:20:19.512 +0000 [ERROR]: 	at java.lang.Thread.run(Thread.java:750)
2025-11-10 00:20:19.512 +0000 [ERROR]: 2025-11-10 00:20:19.512 +0000 [ERROR]: Error: java.lang.RuntimeException: java.lang.NoSuchMethodError: org.embulk.spi.PageBuilder.setTimestamp(Lorg/embulk/spi/Column;Ljava/time/Instant;)V
```

</details>
